### PR TITLE
Changes the name validation regex to allow leading capital letters.

### DIFF
--- a/lib/email_inquire/validator/email_format.rb
+++ b/lib/email_inquire/validator/email_format.rb
@@ -24,14 +24,14 @@ module EmailInquire
         \z
       /x.freeze
 
-      NAME_ALLOWED_CHARS = /[a-z0-9._%+-]/.freeze
+      NAME_ALLOWED_CHARS = "a-z0-9._%+-".freeze
 
       NAME_REGEXP = /
         \A
         [a-z0-9]
         [#{NAME_ALLOWED_CHARS}]{0,63}
         \z
-      /x.freeze
+      /ix.freeze
 
       # Relevant literature:
       # http://emailregex.com/email-validation-summary/

--- a/spec/email_inquire/validator/email_format_spec.rb
+++ b/spec/email_inquire/validator/email_format_spec.rb
@@ -84,6 +84,15 @@ RSpec.describe EmailInquire::Validator::EmailFormat do
         expect(described_class.validate("john.doe%test@domain.com")).to eq(nil)
       end
 
+      it "returns nil for a name starting with a capital letter" do
+        expect(described_class.validate("John.doe@domain.com")).to eq(nil)
+      end
+
+      it "returns an invalid response for a name starting with a non-alphanumeric character" do
+        expect(described_class.validate("+john.doe@domain.com")).to be_a(EmailInquire::Response)
+          .and be_invalid
+      end
+
       it "returns an invalid response for a name containing non ascii char" do
         expect(described_class.validate("john.dôe@domain.com")).to be_a(EmailInquire::Response)
           .and be_invalid


### PR DESCRIPTION
The regex that validates the name part of the email address was built up by interpolating a regex expressing the character class of allowable name characters into another regex. This had some unusual consequences. The resulting name part regex looked like this:

/\A[a-z0-9][(?-mix:[a-z'0-9._&%+-])]{0,63}\z/x

This meant that only characters after the first character were matched case-insensitive. It also allowed a multiline match for characters after the first. This didn't seem intentional, and capital letters are perfectly fine in email addresses.

The fix is to express the allowed characters as a string and interpolate that string into the regex, and to make the entire regex case-insensitive.

The name regex also forbids non-alphanumeric leading characters in the name part. This seemed intentional, so this commit adds a spec to document that behavior.